### PR TITLE
🐛 Feat: Emit teacherLeft event on producer disconnection

### DIFF
--- a/server.js
+++ b/server.js
@@ -198,6 +198,10 @@ async function runSocketServer() {
             continue;
           }
 
+          //teacherLeft 이벤트 emit
+          socket.to(roomId).emit('teacherLeft');
+          console.log(roomId);
+
           if (producers[socket.id][producerKind]) {
             transportId=producers[socket.id][producerKind].transportId;
             producerId=producers[socket.id][producerKind].producerId;
@@ -222,6 +226,7 @@ async function runSocketServer() {
         //TODO 방에 참여중인 컨슈머 모두 disconnect
       }
       console.log(`client disconnected: ${roomId}`);
+      socket.leave(roomId);
     });
 
     socketServer.on('connect_error', (err) => {


### PR DESCRIPTION
When a producer disconnects, the 'teacherLeft' event is now emitted to all clients in the corresponding room. This update ensures that connected clients are properly notified of the teacher's departure.

### Description

선생님이 라이브 강의실에서 나가는 경우 teacherLeft 이벤트를 같은 방의 참여자에게 브로드 케스트하여
클라이언트가 이에 대응하도록 한다.

### Related Issues

- Resolves #12 

### Screenshots or Video

None

### Testing

None

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

None
